### PR TITLE
Pass object that implements FileInterface to Resource model.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .swp
 /vendor/
 /composer.phar
+/composer.lock
 .DS_Store

--- a/src/Evernote/File/File.php
+++ b/src/Evernote/File/File.php
@@ -17,20 +17,32 @@ class File extends \SplFileObject implements FileInterface
         'application/pdf'
     );
 
-    public function __construct($path, $mime_type, $width = null, $height = null)
+    public function __construct($path, $mime_type = null, $width = null, $height = null)
     {
         if (!is_file($path)) {
             throw new \Exception('File not found : ' . $path);
         }
 
-        if (in_array($mime_type, $this->resizableMimeType)) {
+        parent::__construct($path);
+
+        $this->findMimeType($path);
+        $this->mimeType = $mime_type ?: $this->findMimeType($path);
+
+        if (in_array($this->mimeType, $this->resizableMimeType)) {
             $this->width  = $width;
             $this->height = $height;
         }
+    }
 
-        $this->mimeType = $mime_type;
+    public function getContent()
+    {
+        $file_content = '';
 
-        parent::__construct($path);
+        while (!$this->eof()) {
+            $file_content .= $this->fgets();
+        }
+
+        return $file_content;
     }
 
     public function getMimeType()
@@ -54,5 +66,21 @@ class File extends \SplFileObject implements FileInterface
         return $this->width;
     }
 
+    /**
+     * Find the file's mime type.
+     *
+     * @return string
+     */
+    private function findMimeType($path)
+    {
+        $finfo = finfo_open(FILEINFO_MIME_TYPE);
+        $mime_type = finfo_file($finfo, $path);
+        finfo_close($finfo);
 
+        if (strpos($mime_type, ';') !== false) {
+            list($mime_type, $info) = explode(';', $mime_type);
+        }
+        
+        return trim($mime_type);
+    }
 }

--- a/src/Evernote/File/FileInterface.php
+++ b/src/Evernote/File/FileInterface.php
@@ -6,4 +6,5 @@ interface FileInterface
 {
     public function getMimeType();
     public function getFilename();
+    public function getContent();
 } 

--- a/src/Evernote/Model/Resource.php
+++ b/src/Evernote/Model/Resource.php
@@ -21,15 +21,14 @@ class Resource
 
     protected $attributes;
 
-    public function __construct($path, $mime, $width = null, $height = null)
+    public function __construct($file, $mime = null, $width = null, $height = null)
     {
-        $this->file = new File($path, $mime, $width, $height);
-
-        $file_content = '';
-        while (!$this->file->eof()) {
-            $file_content .= $this->file->fgets();
+        $this->file = $file;
+        if (!$file instanceof FileInterface) {
+            $this->file = new File($file, $mime, $width, $height);
         }
 
+        $file_content = $this->file->getContent();
         $this->hash = md5($file_content, 0);
 
         $data           = new Data();


### PR DESCRIPTION
I've changed the following things.
- The `Resource` model can now accept an object that implements the `FileInterface` instead of just path and mime type.
- The `$mime_type` parameter in the `Resource` model is now optional.
- Added a `findMimeType()` method to `File` class. The `$mime_type` parameter on the `File` class is also optional now.
- Moved local file system related actions to the `File` class into a `getContent()` method.
- Added `getContent()` method to the `FileInterface`.

This decouples the `Resource` model from the file system and allows for adapters to be written to pull in files from services like S3 or Dropbox.

Here's what a [Flysystem](http://flysystem.thephpleague.com) adapter could look like:

``` php

namespace Evernote\File\Adapters;

use Evernote\File\FileInterface;
use League\Flysystem\FilesystemInterface;

class FlysystemAdapter implements FileInterface
{
    /**
     * Filesystem.
     * @var League\Flysystem\FilesystemInterface
     */
    protected $filesystem;

    /**
     * File path.
     * @var string
     */
    protected $path;

    /**
     * FlySystem File Class.
     * 
     * @param string $path
     * @param League\Flysystem\FilesystemInterface $filesystem
     * @return void
     */ 
    public function __construct($path, FilesystemInterface $filesystem) {
        $this->path = $path;
        $this->filesystem = $filesystem;
    }

    /**
     * Get the filename.
     * 
     * @return string
     */
    public function getFilename()
    {
        $path = explode(DIRECTORY_SEPARATOR, $this->path);
        return array_pop($path);
    }

    /**
     * Get the file's content.
     * 
     * @return string
     */
    public function getContent()
    {
        return $this->filesystem->read($this->path);
    }

    /**
     * Get the file's mimetype.
     * 
     * @return string
     */
    public function getMimetype()
    {
        return $this->filesystem->getMimetype($this->path);
    }
}

```
