### PR TITLE
inverse xml and dtd declaration

### DIFF
--- a/src/Evernote/Model/EnmlNoteContent.php
+++ b/src/Evernote/Model/EnmlNoteContent.php
@@ -11,14 +11,14 @@ class EnmlNoteContent extends NoteContent implements NoteContentInterface
 
     public function __construct($content, HtmlConverterInterface $htmlConverter = null)
     {
-        if (!$this->hasXmlDeclaration($content)) {
-            $content = $this->addXmlDeclaration($content);
-        }
-        
         if (!$this->hasDoctypeDeclaration($content)) {
             $content = $this->addDoctypeDeclaration($content);
         }
-        
+
+        if (!$this->hasXmlDeclaration($content)) {
+            $content = $this->addXmlDeclaration($content);
+        }
+
         $this->content   = $content;
         $this->htmlConverter = $htmlConverter;
     }


### PR DESCRIPTION
In relation with #31 

If the xml declaration and the doctype are missing, the result was

```xml
<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">
<en-note><?xml version='1.0' encoding='utf-8'?>

<!-- content -->

</en-note>
```

The expected result is:

```xml
<?xml version='1.0' encoding='utf-8'?>
<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">
<en-note>

<!-- content -->

</en-note>
```

I have inverted the two declarations tests to inject the xml tag the last.