### PR TITLE
Fix DIR in HtmlToEnmlConverter

### DIFF
--- a/src/Evernote/Enml/Converter/HtmlToEnmlConverter.php
+++ b/src/Evernote/Enml/Converter/HtmlToEnmlConverter.php
@@ -44,7 +44,7 @@ class HtmlToEnmlConverter implements EnmlConverterInterface
         $content = $this->cleanHtml($content);
 
         //Transform to ENML via XSLT
-        $enml_body = $this->xslTransform($content, 'html2enml.xslt');
+        $enml_body = $this->xslTransform($content, __DIR__ . '/html2enml.xslt');
 
         $enml = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
HtmlToEnmlConverter imports `html2enml.xslt` always from the current working directory.
This is an issue when I try to use it in my project - it throws file not found errors.

EnmlToHtml converter uses `__DIR__` when importing the same xslt: https://github.com/artpi/evernote-cloud-sdk-php/blob/master/src/Evernote/Enml/Converter/EnmlToHtmlConverter.php#L9

That is what I did here.
