### PR TITLE
Support and fixes for php8.0 or higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,18 @@
         "forum": "https://discussion.evernote.com/forum/61-evernote-for-developers/"
     },
     "require": {
-        "php": ">=5.3",
+        "php": ">=8.0",
         "ezyang/htmlpurifier": "^4.6.0",
         "tijsverkoyen/css-to-inline-styles": "~2.2",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "ext-curl": "*",
+        "ext-fileinfo": "*"
     },
     "autoload": {
         "psr-0": { "Evernote": "src/", "Thrift": "src/"},
         "classmap": ["src/EDAM"]
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
     }
 }

--- a/src/Thrift/Protocol/TJSONProtocol.php
+++ b/src/Thrift/Protocol/TJSONProtocol.php
@@ -194,7 +194,7 @@ class TJSONProtocol extends TProtocol
     }
 
     private function hexVal($s) {
-        for ($i = 0; $i < strlen($s); $i++) {
+        for ($i = 0, $iMax = strlen($s); $i < $iMax; $i++) {
             $ch = substr($s, $i, 1);
 
             if (!($ch >= "a" && $ch <= "f") && !($ch >= "0" && $ch <= "9")) {

--- a/src/Thrift/Transport/THttpClient.php
+++ b/src/Thrift/Transport/THttpClient.php
@@ -97,7 +97,7 @@ class THttpClient extends TTransport {
    * @param string $uri
    */
   public function __construct($host, $port=80, $uri='', $scheme = 'http') {
-    if ((TStringFuncFactory::create()->strlen($uri) > 0) && ($uri{0} != '/')) {
+    if ((TStringFuncFactory::create()->strlen($uri) > 0) && ($uri[0] != '/')) {
       $uri = '/'.$uri;
     }
     $this->scheme_ = $scheme;


### PR DESCRIPTION
The current min version of php with 5.3 is very outdated. This PR raises the min version to 8.0 and contains fixes to support php 8.0 or higher