### PR TITLE
Remove curly braces deprecated in PHP 7.4

### DIFF
--- a/src/Thrift/Transport/THttpClient.php
+++ b/src/Thrift/Transport/THttpClient.php
@@ -97,7 +97,7 @@ class THttpClient extends TTransport {
    * @param string $uri
    */
   public function __construct($host, $port=80, $uri='', $scheme = 'http') {
-    if ((TStringFuncFactory::create()->strlen($uri) > 0) && ($uri{0} != '/')) {
+    if ((TStringFuncFactory::create()->strlen($uri) > 0) && ($uri[0] != '/')) {
       $uri = '/'.$uri;
     }
     $this->scheme_ = $scheme;

--- a/src/Thrift/Transport/THttpClient.php
+++ b/src/Thrift/Transport/THttpClient.php
@@ -97,7 +97,7 @@ class THttpClient extends TTransport {
    * @param string $uri
    */
   public function __construct($host, $port=80, $uri='', $scheme = 'http') {
-    if ((TStringFuncFactory::create()->strlen($uri) > 0) && ($uri[0] != '/')) {
+    if ((TStringFuncFactory::create()->strlen($uri) > 0) && (substr($uri, 0, 1) != '/')) {
       $uri = '/'.$uri;
     }
     $this->scheme_ = $scheme;


### PR DESCRIPTION
Solves #45 

This PR fixes the curly braces notation of [THttpClient.php](https://github.com/Evernote/evernote-cloud-sdk-php/compare/master...artpi:evernote-cloud-sdk-php:fix-curly-braces?expand=1#diff-8e96ceb326383f8a9d2dea0c025f6bb307af5a943ad9b50aa3e63a36b745a101) deprecated in 7.4 

> In PHP, using array and string offset access syntax with curly braces has been deprecated as of PHP 7.4. This means that using curly braces to access elements of an array or characters in a string is no longer considered good practice, and support for this syntax may be removed in a future version of PHP.


https://www.w3docs.com/snippets/php/array-and-string-offset-access-syntax-with-curly-braces-is-deprecated.html